### PR TITLE
Add versioned configs with ConfigTrait

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,35 +1,40 @@
 release_path = "/home/asonix/Development/rust/releases/"
-license = "LICENSE"
-readme = "README.md"
-
-[config.Windows.amd64]
-libs = ["/usr/x86_64-w64-mingw32"]
-env = {}
-
-[config.Linux.aarch64]
-libs = ["/usr/aarch64-linux-gnu", "/home/asonix/Development/aarch64"]
-env = {}
-
+included_files = ["README.md", "LICENSE"]
 [config.Linux.armv7h]
 libs = ["/usr/arm-linux-gnueabihf", "/home/asonix/Development/armeabi"]
-env = {}
+
+[config.Linux.armv7h.env]
 
 [config.Linux.armv7hmusl]
 libs = ["/usr/arm-linux-gnueabihf"]
-env = {}
 
-[config.Linux.armh]
-libs = ["/usr/arm-linux-gnueabihf", "/home/asonix/Development/armeabi"]
-env = {}
-
-[config.Linux.armhmusl]
-libs = ["/usr/arm-linux-gnueabihf"]
-env = {}
-
-[config.Linux.amd64]
-libs = []
-env = {}
+[config.Linux.armv7hmusl.env]
 
 [config.Linux.amd64musl]
 libs = []
-env = {}
+
+[config.Linux.amd64musl.env]
+
+[config.Linux.armh]
+libs = ["/usr/arm-linux-gnueabihf", "/home/asonix/Development/armeabi"]
+
+[config.Linux.armh.env]
+
+[config.Linux.aarch64]
+libs = ["/usr/aarch64-linux-gnu", "/home/asonix/Development/aarch64"]
+
+[config.Linux.aarch64.env]
+
+[config.Linux.amd64]
+libs = []
+
+[config.Linux.amd64.env]
+
+[config.Linux.armhmusl]
+libs = ["/usr/arm-linux-gnueabihf"]
+
+[config.Linux.armhmusl.env]
+[config.Windows.amd64]
+libs = ["/usr/x86_64-w64-mingw32"]
+
+[config.Windows.amd64.env]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,106 @@
+// This file is part of Release Manager
+
+// Release Manager is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Release Manager is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Release Manager  If not, see <http://www.gnu.org/licenses/>.
+
+use std::convert::TryFrom;
+use std::collections::HashMap;
+use std::path::Path;
+use std::fs::File;
+use std::io::Write;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use toml;
+
+use super::{Arch, OS, Target, Error};
+use super::parse_toml;
+
+mod v0;
+mod v1;
+
+pub use self::v1::Config;
+
+#[derive(Debug, PartialEq)]
+pub enum ConfigState {
+    Current,
+    Upgraded,
+}
+
+pub trait ConfigTrait: DeserializeOwned + Serialize + Sized {
+    type Previous: ConfigTrait + Into<Self>;
+
+    fn new(filename: &Path) -> Result<(Self, ConfigState), Error> {
+        parse_toml(filename)
+            .map(|c| (c, ConfigState::Current))
+            .or_else(|e| {
+                Self::Previous::new(filename)
+                    .map(|(c, _)| {
+                        debug!("Upgrading from older config version");
+                        (c.into(), ConfigState::Upgraded)
+                    })
+                    .map_err(|_| e)
+            })
+    }
+
+    fn targets(&self) -> Vec<Target>;
+
+    fn save(&self, path: &Path) -> Result<(), Error> {
+        let mut f = File::create(path)?;
+        write!(f, "{}", toml::to_string(&self)?)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct EmptyConfig;
+
+impl ConfigTrait for EmptyConfig {
+    type Previous = EmptyConfig;
+
+    fn new(_: &Path) -> Result<(Self, ConfigState), Error> {
+        Err(Error::Config)
+    }
+
+    fn targets(&self) -> Vec<Target> {
+        Vec::new()
+    }
+
+    fn save(&self, _: &Path) -> Result<(), Error> {
+        Err(Error::Config)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TargetConfig {
+    libs: Vec<String>,
+    env: HashMap<String, String>,
+}
+
+fn add_target(targets: &mut Vec<Target>, os: OS, arch: Arch, tc: &TargetConfig) {
+    if let Ok(mut target) = Target::new(os.clone(), arch) {
+        target.add_libs(&tc.libs);
+        target.add_env(&tc.env);
+        targets.push(target);
+    }
+}
+
+fn build_os(targets: &mut Vec<Target>, os: OS, value: &HashMap<String, TargetConfig>) {
+    for (arch, tc) in value.iter() {
+        if let Ok(arc) = Arch::try_from(arch.as_ref()) {
+            add_target(targets, os.clone(), arc, tc);
+        } else {
+            debug!("{} is not a valid architecture!", arch);
+        }
+    }
+}

--- a/src/config/v0.rs
+++ b/src/config/v0.rs
@@ -1,0 +1,58 @@
+// This file is part of Release Manager
+
+// Release Manager is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Release Manager is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Release Manager  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use super::{ConfigTrait, TargetConfig, Target, OS};
+use super::build_os;
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub release_path: String,
+    pub license: String,
+    pub readme: String,
+    pub config: HashMap<String, HashMap<String, TargetConfig>>,
+}
+
+impl ConfigTrait for Config {
+    type Previous = super::EmptyConfig;
+
+    fn targets(&self) -> Vec<Target> {
+        let mut targets = Vec::new();
+
+        for (os, value) in self.config.iter() {
+            let opsys = OS::try_from(os.as_ref());
+            if opsys.is_err() {
+                debug!("{}, is not a valid Operating System!", os);
+            } else {
+                build_os(&mut targets, opsys.unwrap(), value);
+            }
+        }
+
+        targets
+    }
+}
+
+impl From<super::EmptyConfig> for Config {
+    fn from(_: super::EmptyConfig) -> Self {
+        Config {
+            release_path: String::new(),
+            license: String::new(),
+            readme: String::new(),
+            config: HashMap::new(),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
     RePublish,
     /// Some builds failed
     FailedBuilds,
+    /// Failed to parse Config
+    Config,
 }
 
 impl fmt::Display for Error {
@@ -69,6 +71,7 @@ impl fmt::Display for Error {
             Error::NotTable => write!(f, "Expected a toml::Value::Table, got somethign else"),
             Error::RePublish => write!(f, "Cannot re-publish an already published crate"),
             Error::FailedBuilds => write!(f, "Some builds failed"),
+            Error::Config => write!(f, "Error building config"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ use toml::Value;
 
 pub use target::{Arch, OS, Target};
 pub use error::Error;
-pub use config::{Config, TargetConfig};
+pub use config::{Config, ConfigState, ConfigTrait, TargetConfig};
 pub use status::{StatusWrapper, Status, VersionStatus, BuildStatus};
 pub use commandline::Opt;
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -33,36 +33,18 @@ pub enum Arch {
 
 impl<'a> TryFrom<&'a str> for Arch {
     type Error = &'a str;
-    fn try_from(value : &'a str) -> Result<Arch, &'a str>{
+    fn try_from(value: &'a str) -> Result<Arch, &'a str> {
         match value {
-            "aarch64" => {
-                Ok(Arch::Aarch64)
-            }
-            "armv7h" => {
-                Ok(Arch::Armv7h)
-            }
-            "armv7hmusl" => {
-                Ok(Arch::Armv7hMusl)
-            }
-            "armh" => {
-                Ok(Arch::Armh)
-            }
-            "armhmmusl" => {
-                Ok(Arch::ArmhMusl)
-            }
-            "amd64" => {
-                Ok(Arch::Amd64)
-            }
-            "amd64musl" => {
-                Ok(Arch::Amd64Musl)
-            }
-            "i686" => {
-                Ok(Arch::I686)
-            }
+            "aarch64" => Ok(Arch::Aarch64),
+            "armv7h" => Ok(Arch::Armv7h),
+            "armv7hmusl" => Ok(Arch::Armv7hMusl),
+            "armh" => Ok(Arch::Armh),
+            "armhmusl" => Ok(Arch::ArmhMusl),
+            "amd64" => Ok(Arch::Amd64),
+            "amd64musl" => Ok(Arch::Amd64Musl),
+            "i686" => Ok(Arch::I686),
 
-            _ => {
-                Err(value)
-            }
+            _ => Err(value),
         }
     }
 }
@@ -177,20 +159,13 @@ impl Target {
 
 impl<'a> TryFrom<&'a str> for OS {
     type Error = &'a str;
-    fn try_from(value : &'a str) -> Result<OS, &'a str>{
+
+    fn try_from(value: &'a str) -> Result<OS, &'a str> {
         match value {
-            "Linux" => {
-                Ok(OS::Linux)
-            }
-            "Windows" => {
-                Ok(OS::Windows)
-            }
-            "Mac" => {
-                Ok(OS::Mac)
-            }
-            _ => {
-                Err(value)
-            }
+            "Linux" => Ok(OS::Linux),
+            "Windows" => Ok(OS::Windows),
+            "Mac" => Ok(OS::Mac),
+            _ => Err(value),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/asonix/release-manager/issues/3

Introduce a ConfigTrait that all future variations of Config should inherit from. ConfigTrait provides implementations for `new()` and `save()` so future versions of Config can serialized/deserialized to files easily.

This also includes some formatting changes for the TryFrom implementations of Arch and OS