### PR TITLE
Introduce build_names

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -1,41 +1,42 @@
 release_path = "/home/asonix/Development/rust/releases/"
 included_files = ["README.md", "LICENSE", "ACKNOWLEDGEMENTS"]
 
-[config.Linux.armv7h]
+[[config.Linux.armhmusl]]
+libs = ["/usr/arm-linux-gnueabihf"]
+
+[config.Linux.armhmusl.env]
+
+[[config.Linux.armv7h]]
 libs = ["/usr/arm-linux-gnueabihf", "/home/asonix/Development/armeabi"]
 
 [config.Linux.armv7h.env]
 
-[config.Linux.armv7hmusl]
-libs = ["/usr/arm-linux-gnueabihf"]
-
-[config.Linux.armv7hmusl.env]
-
-[config.Linux.amd64musl]
-libs = []
-
-[config.Linux.amd64musl.env]
-
-[config.Linux.armh]
-libs = ["/usr/arm-linux-gnueabihf", "/home/asonix/Development/armeabi"]
-
-[config.Linux.armh.env]
-
-[config.Linux.aarch64]
+[[config.Linux.aarch64]]
 libs = ["/usr/aarch64-linux-gnu", "/home/asonix/Development/aarch64"]
 
 [config.Linux.aarch64.env]
 
-[config.Linux.amd64]
+[[config.Linux.amd64musl]]
+libs = []
+
+[config.Linux.amd64musl.env]
+
+[[config.Linux.armv7hmusl]]
+libs = ["/usr/arm-linux-gnueabihf"]
+
+[config.Linux.armv7hmusl.env]
+
+[[config.Linux.armh]]
+libs = ["/usr/arm-linux-gnueabihf", "/home/asonix/Development/armeabi"]
+
+[config.Linux.armh.env]
+
+[[config.Linux.amd64]]
 libs = []
 
 [config.Linux.amd64.env]
 
-[config.Linux.armhmusl]
-libs = ["/usr/arm-linux-gnueabihf"]
-
-[config.Linux.armhmusl.env]
-[config.Windows.amd64]
+[[config.Windows.amd64]]
 libs = ["/usr/x86_64-w64-mingw32"]
 
 [config.Windows.amd64.env]

--- a/src/commandline.rs
+++ b/src/commandline.rs
@@ -19,6 +19,8 @@
 pub struct Opt {
     #[structopt(short = "f", long = "force", help = "Force recompiling of succeeded builds")]
     force_compile: bool,
+    #[structopt(long = "skip-dependencies", help = "Don't compile dependencies unless needed")]
+    skip_dependencies: bool,
     #[structopt(short = "p", long = "publish", help = "Publish to crates.io on succesfull build")]
     publish: bool,
     #[structopt(long = "verbose", help = "Print debug info")]
@@ -42,6 +44,10 @@ impl Opt {
 
     pub fn verbose(&self) -> bool {
         self.verbose
+    }
+
+    pub fn skip_dependencies(&self) -> bool {
+        self.skip_dependencies
     }
 
     pub fn release_config(&self) -> Option<&str> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,8 +27,9 @@ use super::parse_toml;
 
 mod v0;
 mod v1;
+mod v2;
 
-pub use self::v1::Config;
+pub use self::v2::Config;
 
 #[derive(Debug, PartialEq)]
 pub enum ConfigState {
@@ -88,7 +89,7 @@ pub struct TargetConfig {
 }
 
 fn add_target(targets: &mut Vec<Target>, os: OS, arch: Arch, tc: &TargetConfig) {
-    if let Ok(mut target) = Target::new(os.clone(), arch) {
+    if let Ok(mut target) = Target::new(os.clone(), arch, None) {
         target.add_libs(&tc.libs);
         target.add_env(&tc.env);
         targets.push(target);

--- a/src/config/v2.rs
+++ b/src/config/v2.rs
@@ -1,0 +1,107 @@
+// This file is part of Release Manager
+
+// Release Manager is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Release Manager is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Release Manager  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use super::{ConfigTrait, Target, Arch, OS};
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub release_path: String,
+    pub included_files: Vec<String>,
+    pub config: HashMap<String, HashMap<String, Vec<TargetConfig>>>,
+}
+
+impl Config {
+    pub fn included_files(&self) -> &[String] {
+        self.included_files.as_ref()
+    }
+}
+
+impl ConfigTrait for Config {
+    type Previous = super::v1::Config;
+
+    fn targets(&self) -> Vec<Target> {
+        let mut targets = Vec::new();
+
+        for (os_str, value) in self.config.iter() {
+            if let Ok(os) = OS::try_from(os_str.as_ref()) {
+                build_os(&mut targets, os, value);
+            } else {
+                debug!("{}, is not a valid Operating System!", os_str);
+            }
+        }
+
+        targets
+    }
+}
+
+impl From<super::v1::Config> for Config {
+    fn from(c: super::v1::Config) -> Self {
+        let mut config: HashMap<String, HashMap<String, Vec<TargetConfig>>> = HashMap::new();
+
+        for (os, arch_hash) in c.config {
+            for (arch, target) in arch_hash {
+                let os_entry = config.entry(os.clone().into()).or_insert(HashMap::new());
+                let arch_entry = os_entry.entry(arch.into()).or_insert(Vec::new());
+                arch_entry.push(target.into());
+            }
+        }
+
+        Config {
+            release_path: c.release_path,
+            included_files: c.included_files,
+            config: config,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TargetConfig {
+    build_name: Option<String>,
+    libs: Vec<String>,
+    env: HashMap<String, String>,
+}
+
+impl From<super::TargetConfig> for TargetConfig {
+    fn from(tc: super::TargetConfig) -> Self {
+        TargetConfig {
+            build_name: None,
+            libs: tc.libs,
+            env: tc.env,
+        }
+    }
+}
+
+fn add_target(targets: &mut Vec<Target>, os: OS, arch: Arch, tc: &TargetConfig) {
+    if let Ok(mut target) = Target::new(os.clone(), arch, tc.build_name.clone()) {
+        target.add_libs(&tc.libs);
+        target.add_env(&tc.env);
+        targets.push(target);
+    }
+}
+
+fn build_os(targets: &mut Vec<Target>, os: OS, value: &HashMap<String, Vec<TargetConfig>>) {
+    for (arch, tcs) in value.iter() {
+        if let Ok(arc) = Arch::try_from(arch.as_ref()) {
+            for target in tcs {
+                add_target(targets, os.clone(), arc.clone(), target);
+            }
+        } else {
+            debug!("{} is not a valid architecture!", arch);
+        }
+    }
+}


### PR DESCRIPTION
This allows multiple builds per architecure, each
with its own environment and libraries. This can be
useful for making multiple builds of a -musl target
while using different versions of the dependencies
like OpenSSL 1.0 vs 1.1.

This also clarifies in Status.toml when the -f option
is used, which builds have not yet been completed. It
sets the build's status to Waiting initially, and then
the build transitions through Started to Success or
Failed.

Additionally, before each build, the target's directory
gets cleaned. This is important for when multiple
builds use the same architecture, so dependencies can
get recompiled against other libraries. In order to
avoid needless compiling of dependencies for projects
that do not need to take advantage of multiple targets
for a certain architecture, the --skip-dependencies
flag has been added.

Fixes https://github.com/asonix/release-manager/issues/1